### PR TITLE
Create docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@ cmake-build-debug
 build_old
 .idea
 build
+assets

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM alpine
+
+RUN echo "https://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories && \
+	echo "https://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories
+
+RUN apk update && \
+	apk add curl curl-dev sqlite-dev libgcrypt-dev alpine-sdk cmake make
+
+# Copy application now
+WORKDIR /app
+COPY ./ /app
+
+RUN cmake -S /app -B build -D DROPOUT_DL_BUILD_ALL=true
+WORKDIR /app/build
+RUN make && \
+	chmod +x dropout-dl-* && \
+	cp dropout-dl-* ../
+
+WORKDIR /app
+
+ENTRYPOINT [ "/app/dropout-dl-full" ]

--- a/readme.md
+++ b/readme.md
@@ -6,9 +6,11 @@ dropout-dl is tool to download [dropout.tv](https://www.dropout.tv) episodes. It
 
 
 * [Installation](#installation)
+  * [Docker](#docker)
   * [How to Build](#how-to-build)
   * [Dependencies](#Dependencies)
 * [Usage](#how-to-use)
+  
   * [Options](#options)
   * [Login](#login)
   * [Cookies](#cookies)
@@ -16,6 +18,18 @@ dropout-dl is tool to download [dropout.tv](https://www.dropout.tv) episodes. It
 
 
 # Installation
+## Docker
+A docker image was created that makes it easier to build and use dropout-dl. You can simply build the docker image without worrying about installing any system dependencies:
+```shell
+docker build -t dropout-dl:latest .
+```
+After its done building, you can use it by adding your arguments to the end of the `docker run` command:
+```shell
+docker run --rm -it -v $PWD/login:/app/login -v $PWD/out:/Downloads dropout-dl:latest --output-directory /Downloads --captions -e https://www.dropout.tv/dimension-20/season:10/videos/the-chosen-ones
+```
+**Note:** The docker image expects the `login` file to be at `/app/login`.\
+You must specify an output directory and mount that directory to the host so that you can retrieve the files from the docker container. In the above command I tell dropout-dl to output everything in `/Downloads` inside the container, which is mounted to a folder named `out` inside the current directory (`$PWD` is current directory).
+
 ## How to Build
 ```
 cmake -S <source-dir> -B <build-dir>


### PR DESCRIPTION
I made a docker image that makes it easier to use this project. I built this to run the downloads overnight on my server without dealing with system packages for the dependencies. I made this in about 20 minutes, so there might be issues but it seems to work fine on my desktop and my server. I made sure to include a bit about the docker image in the readme.

I haven't added it to the docker hub so other people will have to build it themselves for now.