### PR TITLE
Skip downloading if file exists

### DIFF
--- a/src/episode.cpp
+++ b/src/episode.cpp
@@ -316,10 +316,12 @@ namespace dropout_dl {
 			std::cout << YELLOW << "File already exists: " << filepath << RESET << '\n';
 			return;
 		}
-		std::fstream out(filepath + ".mp4",
-						 std::ios_base::in | std::ios_base::out | std::ios_base::trunc);
+		if (!checkExisting(quality,filepath)){
+			std::fstream out(filepath + ".mp4",
+				std::ios_base::in | std::ios_base::out | std::ios_base::trunc);
 
-		out << this->get_video_data(quality, filepath) << std::endl;
+			out << this->get_video_data(quality, filepath) << std::endl;
+		}
 
 		if (!this->captions_url.empty()) {
 			std::fstream captions_file(filepath + ".vtt",
@@ -363,5 +365,32 @@ namespace dropout_dl {
 		} else {
 			this->download_quality(quality, series_directory, filename);
 		}
+	}
+
+	bool episode::checkExisting(const std::string &quality, const std::string& filename){
+		std::filesystem::path filePath = filename + ".mp4";
+		double fileSize;
+		CURL* curl = curl_easy_init();
+    	CURLcode res;
+		if (curl) {
+			curl_easy_setopt(curl, CURLOPT_URL, get_video_url(quality).c_str());
+			curl_easy_setopt(curl, CURLOPT_NOBODY, 1L);  // Set to HTTP HEAD request
+			curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, dropout_dl::EmptyWriteCallback);
+
+			res = curl_easy_perform(curl);
+
+			if (res == CURLE_OK) {
+				res = curl_easy_getinfo(curl, CURLINFO_CONTENT_LENGTH_DOWNLOAD, &fileSize);
+			}
+			curl_easy_cleanup(curl);
+    	}
+		if (std::filesystem::exists(filePath)) {
+        	std::uintmax_t fileSizeDisk = std::filesystem::file_size(filePath);
+				if (fileSizeDisk-1 == fileSize){
+					return true;
+				}
+				else return false;
+		}
+		else return false;
 	}
 } // dropout_dl

--- a/src/episode.cpp
+++ b/src/episode.cpp
@@ -389,6 +389,9 @@ namespace dropout_dl {
 				if (fileSizeDisk-1 == fileSize){
 					return true;
 				}
+				else if (fileSizeDisk == fileSize){
+					return true;
+				}
 				else return false;
 		}
 		else return false;

--- a/src/episode.h
+++ b/src/episode.h
@@ -133,6 +133,14 @@ namespace dropout_dl {
 		 */
 		std::vector<std::string> get_qualities();
 
+		/**
+		 *
+		 * @return Whether the episode already exists on disk or not.
+		 *
+		 * Compare the <b>filename</b> aswell as the <b>filesize</b> of a to be downloaded episode with files on disk.
+		 */
+		bool checkExisting(const std::string& quality, const std::string& filename = "");
+
 
 		/**
 		 *

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1,4 +1,5 @@
 #include "util.h"
+#include <stdint.h>
 
 namespace dropout_dl {
 	// dropout-dl helpers
@@ -222,6 +223,11 @@ namespace dropout_dl {
 		slist1 = nullptr;
 
 		return page_data;
+	}
+
+	size_t EmptyWriteCallback(void*, size_t, size_t, void*) {
+    // This callback function is needed for CURLOPT_NOBODY to discard the response body.
+    return 0;
 	}
 
 

--- a/src/util.h
+++ b/src/util.h
@@ -108,7 +108,7 @@ namespace dropout_dl {
 	 * Used by curl. Writes the information gathered by curl into the userp string. This function was not written by me.
 	 */
 	size_t WriteCallback(void *contents, size_t size, size_t nmemb, void *userp);
-
+	size_t EmptyWriteCallback(void *contents, size_t size, size_t nmemb, void* userp);
 
 	/**
 	 *


### PR DESCRIPTION
<h1> NEEDS TESTING </h1>

A **VERY** basic implementation that checks the file name and file size to determine if the download should be skipped because it was previously completed.

For some reason, the downloaded file is always* 1 byte larger than what curl reports so I check for filesize-1 as well as exact filesize.

![image_2023-05-27_15-05-13](https://github.com/mosswg/dropout-dl/assets/6434049/39958318-2461-4408-8998-914d57157aba)

*I've only tested with the first 8 episodes of fantasy high.