### PR TITLE
Add optional dependency installation instructions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -49,10 +49,18 @@ make
 ```
 sudo xbps-install -S libcurl
 ```
+To install the optional dependencies, run:
+```
+sudo xbps-install -S sqlite-devel libgcrypt-devel
+```
 
-#### Debian
+#### Debian/Ubuntu
 ```
 sudo apt install libcurl4-gnutls-dev
+```
+To install the optional dependencies, run:
+```
+sudo apt install libsqlite3-dev libgcrypt-dev
 ```
 
 ## How to Use


### PR DESCRIPTION
And also clarify that apt can be used on Debian and Ubuntu based distributions.