### PR TITLE
Fix occasional missing captions

### DIFF
--- a/src/episode.cpp
+++ b/src/episode.cpp
@@ -264,7 +264,7 @@ namespace dropout_dl {
 	}
 
 	std::string episode::get_captions_url() {
-		std::string start = "\"lang\":\"en\",\"url\":\"";
+		std::string start = "\"lang\":\"(en|en-US)\",\"url\":\"";
 		std::string end = "\",\"kind\":\"captions\"";
 
 		if (this->config_data.find(end) == std::string::npos) {

--- a/src/episode.cpp
+++ b/src/episode.cpp
@@ -265,7 +265,7 @@ namespace dropout_dl {
 
 	std::string episode::get_captions_url() {
 		std::string start = "\"lang\":\"(en|en-US)\",\"url\":\"";
-		std::string end = "\",\"kind\":\"captions\"";
+		std::string end = "\",\"kind\":\"(captions|subtitles)\"";
 
 		if (this->config_data.find(end) == std::string::npos) {
 			return "";


### PR DESCRIPTION
Some videos randomly use en-US instead of en, which prevents DDL from downloading captions, so I'm making it check for both.

Also, apparently the "kind" JSON tag is sometimes "subtitles" instead of "captions", which causes breakage, so I changed that regex too.