### PR TITLE
Closes Issues #9 (Suggestion: Add option to download captions only) and #13 (Some videos missing captions)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,6 @@ build_old
 .idea
 build
 assets
+.vscode
+login
+out

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ cmake-build-debug
 build_old
 .idea
 build
+.vscode
+login
+out

--- a/readme.md
+++ b/readme.md
@@ -74,7 +74,8 @@ By default, dropout-dl will download episodes in a season with the format `<seri
 --series            -S   Interpret the url as a link to a series and download all episodes from all seasons
 --season            -s   Interpret the url as a link to a season and download all episodes from all seasons
 --episode           -e   Interpret the url as a link to a single episode
---captions          -c   Download the captions along with the episode
+--captions          -c   Download the captions along with the episode. Overridden by --captions-only if set.
+--captions-only     -co  Download the captions only, without the episode.";
 ```
 
 If series, season, or episode is not used, the type will be inferred based on the link format.

--- a/src/episode.cpp
+++ b/src/episode.cpp
@@ -264,24 +264,42 @@ namespace dropout_dl {
 	}
 
 	std::string episode::get_captions_url() {
-		std::string start = "\"lang\":\"en\",\"url\":\"";
-		std::string end = "\",\"kind\":\"captions\"";
+        /*
+        Different episodes are going to have different start and end points in this config file.
+        These are the options that contributors have found so far.
+        Add to these vectors when new possibilities are discovered.
 
-		if (this->config_data.find(end) == std::string::npos) {
-            //Try again with "subtitles"
-            end = "\",\"kind\":\"subtitles\"";
-            if (this->config_data.find(end) == std::string::npos) {
-                return "";
+        TODO - if Dropout ever adds multiple languages for their captions/subtitles,
+        we'll likely want to add a parameter to this function for the language, and
+        reference that in end_options below.
+        */
+        std::vector<std::string> start_options = {
+            "\"lang\":\"en\",\"url\":\"",
+            "\"lang\":\"en-US\",\"url\":\""
+        };
+
+        std::vector<std::string> end_options = {
+            "\",\"kind\":\"captions\"",
+            "\",\"kind\":\"subtitles\""
+        };
+
+        std::string captions_url;
+        for (const auto& start : start_options) {
+            for (const auto& end : end_options) {
+                if (this->config_data.find(end) != std::string::npos) {
+                    captions_url = dropout_dl::get_substring_in(this->config_data, start, end);
+                    if (!captions_url.empty()) {
+                        if (this->verbose) {
+                            std::cout << "captions url: " << captions_url << "\n";
+                        }
+                        return captions_url;
+                    }
+                }
             }
-		}
+        }
 
-		std::string captions_url = dropout_dl::get_substring_in(this->config_data, start, end);
-		if (this->verbose) {
-			std::cout << "captions url: " << captions_url << "\n";
-		}
-
-		return captions_url;
-	}
+        return "";
+    }
 
 	std::string episode::get_video_url(const std::string& quality) {
 		for (int i = 0; i < qualities.size(); i++) {

--- a/src/episode.cpp
+++ b/src/episode.cpp
@@ -268,7 +268,11 @@ namespace dropout_dl {
 		std::string end = "\",\"kind\":\"captions\"";
 
 		if (this->config_data.find(end) == std::string::npos) {
-			return "";
+            //Try again with "subtitles"
+            end = "\",\"kind\":\"subtitles\"";
+            if (this->config_data.find(end) == std::string::npos) {
+                return "";
+            }
 		}
 
 		std::string captions_url = dropout_dl::get_substring_in(this->config_data, start, end);

--- a/src/episode.cpp
+++ b/src/episode.cpp
@@ -330,7 +330,7 @@ namespace dropout_dl {
 			std::cout << YELLOW << "File already exists: " << filepath << RESET << '\n';
 			return;
 		}
-		if (!check_existing(quality,filepath)){
+		if (!check_existing(quality,filepath) && !this->download_captions_only){
 			std::fstream out(filepath + ".mp4",
 				std::ios_base::in | std::ios_base::out | std::ios_base::trunc);
 

--- a/src/episode.cpp
+++ b/src/episode.cpp
@@ -269,9 +269,11 @@ namespace dropout_dl {
         These are the options that contributors have found so far.
         Add to these vectors when new possibilities are discovered.
 
-        TODO - if Dropout ever adds multiple languages for their captions/subtitles,
-        we'll likely want to add a parameter to this function for the language, and
-        reference that in end_options below.
+        TODO - A cleaner way to do this really is to use a JSON parsing library
+        to grab the array of request.text_tracks from config_data, and then we'll
+        have access all of the options available. Then we could potentially add a
+        parameter to this function for the desired language(s), find that array element,
+        and just grab the "url" property.
         */
         std::vector<std::string> start_options = {
             "\"lang\":\"en\",\"url\":\"",

--- a/src/episode.h
+++ b/src/episode.h
@@ -53,6 +53,8 @@ namespace dropout_dl {
 		std::vector<std::string> qualities;
 		/// The list of the urls correlating with the qualities array.
 		std::vector<std::string> quality_urls;
+        /// Whether to skip the video and only download captions
+        bool download_captions_only;
 
 		/// Whether or not to be verbose
 		bool verbose = false;
@@ -217,7 +219,7 @@ namespace dropout_dl {
 		 * Create an episode object from the link using to cookies to get all the necessary information.
 		 * This constructor initializes all the object data.
 		 */
-		episode(const std::string& episode_url, cookie session_cookie, const std::string& series, const std::string& season, int episode_number, int season_number, bool verbose = false, bool download_captions = false) {
+		episode(const std::string& episode_url, cookie session_cookie, const std::string& series, const std::string& season, int episode_number, int season_number, bool verbose = false, bool download_captions = false, bool download_captions_only = false) {
 			this->episode_url = episode_url;
 			this->verbose = verbose;
 
@@ -291,7 +293,7 @@ namespace dropout_dl {
 
 			this->config_data = get_generic_page(this->config_url);
 
-			if (download_captions) {
+			if (download_captions || download_captions_only) {
 				this->captions_url = get_captions_url();
 				if (verbose) {
 					std::cout << "Got caption url: " << this->captions_url << "\n";
@@ -300,6 +302,8 @@ namespace dropout_dl {
 			else {
 				this->captions_url = "";
 			}
+
+            this->download_captions_only = download_captions_only;
 
 			this->get_qualities();
 		}
@@ -313,7 +317,7 @@ namespace dropout_dl {
 		 * Create an episode object from the link using to cookies to get all the necessary information.
 		 * This constructor initializes all the object data.
 		 */
-		episode(const std::string& episode_url, const cookie& session_cookie, bool verbose = false, bool download_captions = false) {
+		episode(const std::string& episode_url, const cookie& session_cookie, bool verbose = false, bool download_captions = false, bool download_captions_only = false) {
 
 			this->episode_url = episode_url;
 			this->verbose = verbose;
@@ -383,12 +387,14 @@ namespace dropout_dl {
 
 			this->config_data = get_generic_page(this->config_url);
 
-			if (download_captions) {
+			if (download_captions || download_captions_only) {
 				this->captions_url = get_captions_url();
 			}
 			else {
 				this->captions_url = "";
 			}
+
+            this->download_captions_only = download_captions_only;
 
 			this->get_qualities();
 		}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,6 +24,7 @@ namespace dropout_dl {
 		bool is_season = false;
 		bool is_episode = false;
 		bool download_captions = false;
+        bool download_captions_only = false;
 		std::string quality;
 		std::string filename;
 		std::string output_directory;
@@ -117,6 +118,9 @@ namespace dropout_dl {
 				else if (arg == "captions" || arg == "c") {
 					download_captions = true;
 				}
+                else if (arg == "captions-only" || arg == "co") {
+					download_captions_only = true;
+				}
 				else if (arg == "help" || arg == "h") {
 					std::cout << "Usage: dropout-dl [OPTIONS] <url> [OPTIONS]\n"
 								 "\n"
@@ -132,7 +136,8 @@ namespace dropout_dl {
 								 "\t--series            -S   Interpret the url as a link to a series and download all episodes from all seasons\n"
 								 "\t--season            -s   Interpret the url as a link to a season and download all episodes from all seasons\n"
 								 "\t--episode           -e   Interpret the url as a link to a single episode\n"
-								 "\t--captions          -c   Download the captions along with the episode\n";
+								 "\t--captions          -c   Download the captions along with the episode\n"
+                                 "\t--captions-only     -co  Download the captions only, without the episode\n";
 
 					exit(0);
 				}
@@ -372,7 +377,7 @@ int main(int argc, char** argv) {
 		if (options.verbose) {
 			std::cout << "Getting series\n";
 		}
-		dropout_dl::series series(options.url, options.session_cookie, options.download_captions);
+		dropout_dl::series series(options.url, options.session_cookie, options.download_captions, options.download_captions_only);
 
 		series.download(options.quality, options.output_directory);
 	}
@@ -380,7 +385,7 @@ int main(int argc, char** argv) {
 		if (options.verbose) {
 			std::cout << "Getting season\n";
 		}
-		dropout_dl::season season = dropout_dl::series::get_season(options.url, options.session_cookie, options.download_captions);
+		dropout_dl::season season = dropout_dl::series::get_season(options.url, options.session_cookie, options.download_captions, options.download_captions_only);
 
 		season.download(options.quality, options.output_directory + "/" + season.series_name);
 	}
@@ -388,7 +393,7 @@ int main(int argc, char** argv) {
 		if (options.verbose) {
 			std::cout << "Getting episode\n";
 		}
-		dropout_dl::episode ep(options.url, options.session_cookie, options.verbose, options.download_captions);
+		dropout_dl::episode ep(options.url, options.session_cookie, options.verbose, options.download_captions, options.download_captions_only);
 
 		if (options.verbose) {
 			std::cout << "filename: " << options.filename << '\n';

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -136,7 +136,7 @@ namespace dropout_dl {
 								 "\t--series            -S   Interpret the url as a link to a series and download all episodes from all seasons\n"
 								 "\t--season            -s   Interpret the url as a link to a season and download all episodes from all seasons\n"
 								 "\t--episode           -e   Interpret the url as a link to a single episode\n"
-								 "\t--captions          -c   Download the captions along with the episode\n"
+								 "\t--captions          -c   Download the captions along with the episode. Overridden by --captions-only if set.\n"
                                  "\t--captions-only     -co  Download the captions only, without the episode\n";
 
 					exit(0);

--- a/src/season.cpp
+++ b/src/season.cpp
@@ -29,7 +29,7 @@ namespace dropout_dl {
 						if (!episode_text.empty()) {
 							episode_number = get_int_in_string(episode_text);
 						}
-						return episode(html_data.substr(i, j), session_cookie, this->series_name, this->name, episode_number, this->season_number, false, this->download_captions);
+						return episode(html_data.substr(i, j), session_cookie, this->series_name, this->name, episode_number, this->season_number, false, this->download_captions, this->download_captions_only);
 					}
 				}
 			}

--- a/src/season.h
+++ b/src/season.h
@@ -26,6 +26,8 @@ namespace dropout_dl {
 			std::vector<episode> episodes;
 			/// Whether or not to download captions
 			bool download_captions;
+            /// Whether to skip the video and only download captions
+            bool download_captions_only;
 
 			episode get_episode(const std::string& html_data, int& start_point, const cookie& session_cookie);
 
@@ -75,9 +77,10 @@ namespace dropout_dl {
 			 *
 			 * Creates a season object and populates the needed information.
 			 */
-			season(const std::string& url, const std::string& name, const cookie& session_cookie, const std::string& series_name = "", bool download_captions = false) {
+			season(const std::string& url, const std::string& name, const cookie& session_cookie, const std::string& series_name = "", bool download_captions = false, bool download_captions_only = false) {
 				this->url = url;
 				this->download_captions = download_captions;
+                this->download_captions_only = download_captions_only;
 				this->season_number = get_season_number(this->url);
 				this->name = name;
 				this->series_name = series_name;

--- a/src/series.cpp
+++ b/src/series.cpp
@@ -115,7 +115,7 @@ namespace dropout_dl {
 	}
 
 
-	season series::get_season(const std::string &url, const cookie& session_cookie, bool download_captions) {
+	season series::get_season(const std::string &url, const cookie& session_cookie, bool download_captions, bool download_captions_only = false) {
 		std::string html_data = get_generic_page(url);
 
 		std::string search_class("js-switch-season");
@@ -184,7 +184,7 @@ namespace dropout_dl {
 								season_name = season_name.substr(name_start,
 																 season_name.size() - name_start - name_end);
 
-								return {season_url, season_name, session_cookie, get_series_name(html_data), download_captions};
+								return {season_url, season_name, session_cookie, get_series_name(html_data), download_captions, download_captions_only};
 							}
 
 							season_url.clear();

--- a/src/series.cpp
+++ b/src/series.cpp
@@ -91,7 +91,7 @@ namespace dropout_dl {
 							}
 							season_name = season_name.substr(name_start, season_name.size() - name_start - name_end);
 
-							out.emplace_back(season_url, season_name, this->session_cookie, this->name, this->download_captions);
+							out.emplace_back(season_url, season_name, this->session_cookie, this->name, this->download_captions, this->download_captions_only);
 
 							std::cout << out.back().name << ": " << out.back().url << '\n';
 

--- a/src/series.h
+++ b/src/series.h
@@ -28,6 +28,8 @@ namespace dropout_dl {
 			dropout_dl::cookie session_cookie;
 			/// Whether or not to download captions
 			bool download_captions;
+            /// Whether to skip the video and only download captions
+            bool download_captions_only;
 
 			/**
 			 *
@@ -54,7 +56,7 @@ namespace dropout_dl {
 			 *
 			 * Gets the season page, which is really just a series page, and creates a season object with all the episodes of the season
 			 */
-			static season get_season(const std::string& url, const cookie& session_cookie, bool download_captions);
+			static season get_season(const std::string& url, const cookie& session_cookie, bool download_captions, bool download_captions_only);
 
 			/**
 			 *
@@ -72,9 +74,10 @@ namespace dropout_dl {
 			*
 			* Creates a series object and populates the needed variables
 			*/
-			series(const std::string& url, const dropout_dl::cookie& session_cookie, bool download_captions = false) {
+			series(const std::string& url, const dropout_dl::cookie& session_cookie, bool download_captions = false, bool download_captions_only = false) {
 				this->url = url;
 				this->download_captions = download_captions;
+                this->download_captions_only = download_captions_only;
 				this->page_data = get_generic_page(url);
 				this->name = get_series_name(page_data);
 				this->session_cookie = session_cookie;


### PR DESCRIPTION
First, we've addressed #9 

Adds support for a new flag, `--captions-only` or `-co`. If set, video download will be skipped and only captions will be downloaded.

Next, #13 was addressed. The issue states that there are multiple possibilities of values that can exist in the config data when trying to parse out the caption URL. In `episode::get_captions_url()`, I've added a vector with all start possibilities, and a vector with all end possibilities. We now iterate through all possible combinations until a match is found. In my personal testing (primarily with season input `https://www.dropout.tv/dimension-20/season:3` and series input `https://www.dropout.tv/total-forgiveness`), this change resulted in a 100% success rate in subtitle downloads. I'm going to run larger tests on shows with more episodes, and I encourage others to as well, but I think we're gucci here.

It's been 15 years since I've worked in C++ so I welcome any feedback. I also was not sure how to update and run the tests since I was only able to get the app working in Docker, but in Docker it does appear to be working.