### PR TITLE
Series/Season naming

### DIFF
--- a/src/season.h
+++ b/src/season.h
@@ -88,7 +88,7 @@ namespace dropout_dl {
 				this->download_captions_only = download_captions_only;
 				this->season_number = get_season_number(this->url);
 				this->rate_limit = rate_limit;
-				this->name = name;
+				this->name = "Season " + std::to_string(this->season_number);
 				this->series_name = series_name;
 				std::cout << series_name << ": " << name << ": " << "\n";
 				this->page_data = get_generic_page(url);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -100,9 +100,22 @@ namespace dropout_dl {
 		return out;
 	}
 
+	std::string remove_quote_characters(const std::string& str) {
+		std::string out;
+
+		for (int i = 0; i < str.size(); i++) {
+			if (str[i] == '\'') {
+				i++;
+			}
+			out += str[i];
+		}
+
+		return out;
+	}
+
 
 	std::string format_name_string(const std::string& str) {
-		return remove_escaped_characters(replace_html_character_codes(remove_leading_and_following_whitespace(str)));
+		return remove_quote_characters(remove_escaped_characters(replace_html_character_codes(remove_leading_and_following_whitespace(str))));
 	}
 
 	std::string format_filename(const std::string& str) {


### PR DESCRIPTION
"Dimension 20's Adventuring Party" was breaking ffmpeg on the single quote in the series name and the double quotes in the season names. These two seemed like the smallest changes.